### PR TITLE
Tool and Base Settings + Acceleration Command

### DIFF
--- a/src/Machina/Compilers/CompilerKUKA.cs
+++ b/src/Machina/Compilers/CompilerKUKA.cs
@@ -109,8 +109,6 @@ namespace Machina
             initializationLines.Add(";FOLD BCO INI");  // legacy support for user-programming safety
             initializationLines.Add("GLOBAL INTERRUPT DECL 3 WHEN $STOPMESS==TRUE DO IR_STOPM ( )");  // legacy support for user-programming safety
 
-
-
             initializationLines.Add("INTERRUPT ON 3");
             initializationLines.Add("BAS (#INITMOV,0 )");  // use base function to initialize sys vars to defaults
             initializationLines.Add(";ENDFOLD (BCO INI)");
@@ -121,9 +119,6 @@ namespace Machina
             // so we need these two lines to set the tools back to nothing.
             initializationLines.Add("$BASE = $WORLD; setting of the base coordinate system");
             initializationLines.Add("$TOOL = $NULLFRAME; setting of the tool coordinate system");
-
-
-
 
             // excecuting the BCO movment
             initializationLines.Add("joint_pos_tgt = $axis_act_meas");
@@ -553,10 +548,9 @@ namespace Machina
 
                 case ActionType.AttachTool:
                     ActionAttachTool at = (ActionAttachTool)action;
-                    dec = string.Format("BAS(#TOOL, {0})",
+                    dec = string.Format("  $TOOL = {0}",
                         GetToolValue(cursor));
                     break;
-
 
                 case ActionType.DetachTool:
                     ActionDetachTool ad = (ActionDetachTool)action;

--- a/src/Machina/Compilers/CompilerKUKA.cs
+++ b/src/Machina/Compilers/CompilerKUKA.cs
@@ -117,6 +117,14 @@ namespace Machina
             initializationLines.Add(";ENDFOLD (INI)");
             initializationLines.Add("");
 
+            // by default the controller does not revert the tool back to default
+            // so we need these two lines to set the tools back to nothing.
+            initializationLines.Add("$BASE = $WORLD; setting of the base coordinate system");
+            initializationLines.Add("$TOOL = $NULLFRAME; setting of the tool coordinate system");
+
+
+
+
             // excecuting the BCO movment
             initializationLines.Add("joint_pos_tgt = $axis_act_meas");
             initializationLines.Add("PTP joint_pos_tgt");
@@ -477,6 +485,13 @@ namespace Machina
                         cursor.precision);
                     break;
 
+                // There was no acceleration action
+                case ActionType.Acceleration:
+                    dec = string.Format(CultureInfo.InvariantCulture,
+                        "  $ACC.CP = {0}",
+                        cursor.acceleration / 1000.0);
+                    break;
+
                 // @Aratoo 
                 // creating another case for translation as it should not have ABC euler angles in it.
                 // having angles would mess with the orientation of the robot and result in unexpected movements.
@@ -538,9 +553,10 @@ namespace Machina
 
                 case ActionType.AttachTool:
                     ActionAttachTool at = (ActionAttachTool)action;
-                    dec = string.Format("  $TOOL = {0}",
+                    dec = string.Format("BAS(#TOOL, {0})",
                         GetToolValue(cursor));
                     break;
+
 
                 case ActionType.DetachTool:
                     ActionDetachTool ad = (ActionDetachTool)action;
@@ -640,6 +656,12 @@ namespace Machina
                     dec = string.Format(CultureInfo.InvariantCulture,
                         "  $APO.CDIS = {0}",
                         cursor.precision);
+                    break;
+
+                case ActionType.Acceleration:
+                    dec = string.Format(CultureInfo.InvariantCulture,
+                        "  $ACC.CP = {0}",
+                        cursor.acceleration / 1000.0);
                     break;
 
                 case ActionType.Translation:


### PR DESCRIPTION
[] Adding two lines to set Base Plane and Tool Selection to default.
   Doing so seems to solve an issue with the robot going to weird plane orientations.

[] Acceleration action has been implemented.

// To Do
[] Custom command to change IK configuration from the default (010) to other configs. (A feature for more advanced users that 
    what to explore IK configurations)
[] message creation on the controller